### PR TITLE
Don't tslint config.ts

### DIFF
--- a/backend/tslint.json
+++ b/backend/tslint.json
@@ -106,5 +106,8 @@
       "check-separator",
       "check-type"
     ]
+  },
+  "linterOptions": {
+    "exclude": ["src/config.ts"]
   }
 }


### PR DESCRIPTION
This solves an issue where tslint throws an error when you have a long path to CrossCode's assets folder in config.ts (caused by max-line-length)