### PR TITLE
Fixed prop not showing bugs

### DIFF
--- a/webapp/src/app/shared/phaser/entities/registry/prop.ts
+++ b/webapp/src/app/shared/phaser/entities/registry/prop.ts
@@ -222,7 +222,7 @@ export class Prop extends CCEntity {
 		
 		if (anims.sheet || anims.namedSheets) {
 			this.setupAnim(settings, anims, sheetDef, propDef.name, sprites);
-		} else { //<- temporary
+		} else {
 			if (anims.SUB) {
 				for (const anim of anims.SUB as Anims[]) {
 					this.setupAnim(settings, anim, sheetDef, propDef.name, sprites);

--- a/webapp/src/app/shared/phaser/entities/registry/prop.ts
+++ b/webapp/src/app/shared/phaser/entities/registry/prop.ts
@@ -218,21 +218,17 @@ export class Prop extends CCEntity {
 			offset?: Point3;
 			renderMode?: string
 		}[] = [];
-
-
+		
+		
 		if (anims.sheet || anims.namedSheets) {
 			this.setupAnim(settings, anims, sheetDef, propDef.name, sprites);
 		} else { //<- temporary
 			if (anims.SUB) {
-				// TODO: Draw other layers. renderMode doesn't seem to work properly.
-				this.setupAnim(settings, anims.SUB[0] as Anims, sheetDef, propDef.name, sprites);
-				/*
 				for (const anim of anims.SUB as Anims[]) {
 					this.setupAnim(settings, anim, sheetDef, propDef.name, sprites);
-				}*/
+				}
 			}
 		}
-
 		
 		
 		if (sprites.length === 0) {
@@ -271,7 +267,7 @@ export class Prop extends CCEntity {
 			this.entitySettings.sheets.fix.push(fix);
 		}
 	}
-
+	
 	private setupAnim(settings: PropAttributes, anims: Anims, sheetDef: PropSheet, pname: string, sprites: {
 		sheet: AnimSheet;
 		tileOffset: number;
@@ -338,7 +334,8 @@ export class Prop extends CCEntity {
 			sprites.push({
 				sheet: anims.sheet as AnimSheet,
 				alpha: 1,
-				tileOffset: 0
+				tileOffset: 0,
+				renderMode: anims.renderMode
 			});
 		} else {
 			console.error('prop anim has no sheet: ', pname);

--- a/webapp/src/app/shared/phaser/entities/registry/prop.ts
+++ b/webapp/src/app/shared/phaser/entities/registry/prop.ts
@@ -218,7 +218,67 @@ export class Prop extends CCEntity {
 			offset?: Point3;
 			renderMode?: string
 		}[] = [];
+
+
+		if (anims.sheet || anims.namedSheets) {
+			this.setupAnim(settings, anims, sheetDef, propDef.name, sprites);
+		} else { //<- temporary
+			if (anims.SUB) {
+				// TODO: Draw other layers. renderMode doesn't seem to work properly.
+				this.setupAnim(settings, anims.SUB[0] as Anims, sheetDef, propDef.name, sprites);
+				/*
+				for (const anim of anims.SUB as Anims[]) {
+					this.setupAnim(settings, anim, sheetDef, propDef.name, sprites);
+				}*/
+			}
+		}
+
 		
+		
+		if (sprites.length === 0) {
+			console.warn('failed creating prop: ', settings);
+			
+			return this.generateErrorImage();
+		}
+		
+		
+		this.entitySettings.sheets.fix = [];
+		for (const sprite of sprites) {
+			
+			if (!sprite.sheet) {
+				console.error(`prop sheet not found, `, propDef.name);
+				return this.generateErrorImage();
+			}
+			
+			await Helper.loadTexture(sprite.sheet.src, this.scene);
+			
+			const fix = {
+				gfx: sprite.sheet.src,
+				w: sprite.sheet.width,
+				h: sprite.sheet.height,
+				x: sprite.sheet.width * sprite.tileOffset + (sprite.sheet.offX || 0),
+				y: sprite.sheet.offY || 0,
+				alpha: sprite.alpha,
+				offsetX: 0,
+				offsetY: 0,
+				renderMode: sprite.renderMode
+			};
+			
+			if (sprite.offset) {
+				fix.offsetX = sprite.offset.x || 0;
+				fix.offsetY = (sprite.offset.y || 0) - (sprite.offset.z || 0);
+			}
+			this.entitySettings.sheets.fix.push(fix);
+		}
+	}
+
+	private setupAnim(settings: PropAttributes, anims: Anims, sheetDef: PropSheet, pname: string, sprites: {
+		sheet: AnimSheet;
+		tileOffset: number;
+		alpha: number;
+		offset?: Point3;
+		renderMode?: string
+	}[]) {
 		if (anims.namedSheets) {
 			let template: JsonTemplate | undefined;
 			
@@ -229,7 +289,7 @@ export class Prop extends CCEntity {
 				template = templates.find(t => t.name === settings.propAnim);
 				
 				if (!template) {
-					console.error(`prop json template with name ${settings.propAnim} not found, `, propDef.name);
+					console.error(`prop json template with name ${settings.propAnim} not found, `, pname);
 					return this.generateErrorImage();
 				}
 				const name = anims.sheet as string || anims.SUB[0].sheet!;
@@ -281,44 +341,8 @@ export class Prop extends CCEntity {
 				tileOffset: 0
 			});
 		} else {
-			console.error('prop anim has no sheet: ', propDef.name);
+			console.error('prop anim has no sheet: ', pname);
 			return this.generateErrorImage();
-		}
-		
-		if (sprites.length === 0) {
-			console.warn('failed creating prop: ', settings);
-			
-			return this.generateErrorImage();
-		}
-		
-		
-		this.entitySettings.sheets.fix = [];
-		for (const sprite of sprites) {
-			
-			if (!sprite.sheet) {
-				console.error(`prop sheet not found, `, propDef.name);
-				return this.generateErrorImage();
-			}
-			
-			await Helper.loadTexture(sprite.sheet.src, this.scene);
-			
-			const fix = {
-				gfx: sprite.sheet.src,
-				w: sprite.sheet.width,
-				h: sprite.sheet.height,
-				x: sprite.sheet.width * sprite.tileOffset + (sprite.sheet.offX || 0),
-				y: sprite.sheet.offY || 0,
-				alpha: sprite.alpha,
-				offsetX: 0,
-				offsetY: 0,
-				renderMode: sprite.renderMode
-			};
-			
-			if (sprite.offset) {
-				fix.offsetX = sprite.offset.x || 0;
-				fix.offsetY = (sprite.offset.y || 0) - (sprite.offset.z || 0);
-			}
-			this.entitySettings.sheets.fix.push(fix);
 		}
 	}
 }


### PR DESCRIPTION
If a `prop` has `SUB` on `Anims` it seems like all of the `SUB` entries should be displayed. However, this seems to cause some bugs because `renderType: 'lighter'` doesn't seem to work properly.
For now, this PR changes props to draw the first entry which always seems to be the base of the entity.

Example:
![image](https://user-images.githubusercontent.com/2082553/77451923-999f7200-6df5-11ea-87e3-9357b32a7f04.png)
