### PR TITLE
automate release process

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,20 @@
+name: 'build'
+description: 'tests and builds all projects'
+runs:
+  using: "composite"
+  steps:
+    - working-directory: common
+      shell: bash
+      run: |
+        npm ci
+        npm run lint
+        npm run build
+    - working-directory: webapp
+      shell: bash
+      run: |
+        npm ci
+        npm run lint
+        npm run dist
+    - working-directory: backend
+      shell: bash
+      run: npm ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,17 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - master
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-    - run: npm ci
-      working-directory: common
-    - run: npm ci
-      working-directory: backend
-    - run: npm ci
-      working-directory: webapp
-    - run: npm run lint
-      working-directory: common
-    - run: npm run build
-      working-directory: common
-    - run: npm run lint
-      working-directory: webapp
-    - run: npm run dist
-      working-directory: webapp
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: webapp/dist/*
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - uses: ./.github/actions/build

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,55 @@
+name: prepare_release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    name: check release version
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.bumpr.outputs.skip }}
+      version: ${{ steps.bumpr.outputs.next_version }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: bumpr
+        uses: haya14busa/action-bumpr@v1
+        with:
+          dry_run: true
+  prepare:
+    name: prepare release
+    needs: check
+    if: '!needs.check.outputs.skip'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: update changelog
+        run: |
+          export NEXT_VERSION_V=${{ needs.check.outputs.version }}
+          export NEXT_VERSION=${NEXT_VERSION_V:1}
+          sed -i "/\[Unreleased\]/a ## [$NEXT_VERSION] newDateHere" CHANGELOG.md
+          sed -i "s/newDateHere/$(date '+%Y-%m-%d')/g" CHANGELOG.md
+      - name: commit changelog
+        run: |
+          git config --global user.name 'GitHub Action'
+          git config --global user.email 'action@github.com'
+          git commit -am "prepare changelog for release (from GitHub Actions)"
+      - name: make version tag
+        working-directory: webapp
+        run: |
+          mkdir .git
+          npm version ${{ needs.check.outputs.version }}
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          tags: true
+          github_token: ${{ secrets.PAT}}
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,16 @@
+name: pull request
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  require_changelog:
+    name: require changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dangoslen/changelog-enforcer@v1.6.1
+        with:
+          changeLogPath: 'CHANGELOG.md'
+          skipLabels: 'Skip-Changelog'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  build:
+    name: create release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest, ubuntu-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - uses: ./.github/actions/build
+
+      - name: Get version from tag
+        id: tag_name
+        run: |
+          echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
+        shell: bash
+
+      - name: Get Changelog Entry
+        if: matrix.os == 'ubuntu-latest'
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          validation_depth: 10
+          version: ${{ steps.tag_name.outputs.current_version }}
+          path: ./CHANGELOG.md
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          files: webapp/dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improved tile drawing by drawing a line of points instead of single points. Avoids holes when drawing fast. [#189](https://github.com/CCDirectLink/crosscode-map-editor/pull/189)
 - Added keyboard controls to list search overlay (add new entity / add new event)
 - Changed Continuous Integration to Github Actions
+- Automated release build. Should result in more frequent releases
 
 ## [0.8.0] - 2020-09-21
 


### PR DESCRIPTION
- builds the project on every push except on master branch
- pull request also run a check to see if the changelog was changed

prepare release:
- is triggered when a pull request is merged and has a label `bump:x`
- changelog is automatically updated
- package.json and package-lock.json version is updated
- a tag for the version is created
- pushes changes to the repo

release:
- is triggered when a new tag is pushed. Can be manually or through the prepare release step
- builds the binaries on linux, mac and windows
- makes a new release with the binaries and appends the changelog to it
   
   
------
  
This pr requires:  
- 3 new labels `bump:major` `bump:minor` `bump:patch`
- a github personal access token with push access to this repo stored as a secret with the name `PAT`

closes #195