### PR TITLE
Add map pan key control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Add CTRL as a control to pan the camera
+
 ## [0.9.0] 2021-01-01
 
 ### Added

--- a/webapp/src/app/shared/globals.ts
+++ b/webapp/src/app/shared/globals.ts
@@ -9,6 +9,7 @@ import { HttpClientService } from '../services/http-client.service';
 
 export class Globals {
 	static isElectron = false;
+	static panning = false;
 	static game: Phaser.Game;
 	static scene: Phaser.Scene;
 	static map: CCMap;

--- a/webapp/src/app/shared/phaser/entities/entity-manager.ts
+++ b/webapp/src/app/shared/phaser/entities/entity-manager.ts
@@ -149,16 +149,16 @@ export class EntityManager extends BaseObject {
 					this.selectedEntities.forEach(entity => {
 						entity.isDragged = false;
 					});
+
+					// if panning do not deselect entities
+					if (Globals.panning) {
+						return;
+					}
 					
 					if (this.gameObjectDown) {
 						this.gameObjectDown = false;
 					} else {
 						const entities = this.selectionBox.onInputUp();
-
-						// if panning do not deselect entities
-						if (Globals.panning) {
-							return;
-						}
 
 						if (!this.multiSelectKey.isDown) {
 							this.selectEntity();

--- a/webapp/src/app/shared/phaser/entities/entity-manager.ts
+++ b/webapp/src/app/shared/phaser/entities/entity-manager.ts
@@ -112,6 +112,11 @@ export class EntityManager extends BaseObject {
 					entity = gameObject[0].getData('entity') as CCEntity;
 				}
 				
+				// if panning return once entity as been selected to prevent dragging of selected entities
+				if (Globals.panning) {
+					return;
+				}
+
 				if (entity) {
 					this.gameObjectDown = true;
 					
@@ -140,6 +145,12 @@ export class EntityManager extends BaseObject {
 					this.selectEntity();
 					this.showAddEntityMenu();
 				} else if (pointer.leftButtonReleased()) {
+
+					// if panning do not deselect entities
+					if (Globals.panning) {
+						return;
+					}
+
 					this.selectedEntities.forEach(entity => {
 						entity.isDragged = false;
 					});

--- a/webapp/src/app/shared/phaser/entities/entity-manager.ts
+++ b/webapp/src/app/shared/phaser/entities/entity-manager.ts
@@ -144,12 +144,7 @@ export class EntityManager extends BaseObject {
 				if (pointer.rightButtonReleased()) {
 					this.selectEntity();
 					this.showAddEntityMenu();
-				} else if (pointer.leftButtonReleased()) {
-
-					// if panning do not deselect entities
-					if (Globals.panning) {
-						return;
-					}
+				} else if (pointer.leftButtonReleased()) {			
 
 					this.selectedEntities.forEach(entity => {
 						entity.isDragged = false;
@@ -159,6 +154,12 @@ export class EntityManager extends BaseObject {
 						this.gameObjectDown = false;
 					} else {
 						const entities = this.selectionBox.onInputUp();
+
+						// if panning do not deselect entities
+						if (Globals.panning) {
+							return;
+						}
+
 						if (!this.multiSelectKey.isDown) {
 							this.selectEntity();
 						}

--- a/webapp/src/app/shared/phaser/map-pan.ts
+++ b/webapp/src/app/shared/phaser/map-pan.ts
@@ -81,11 +81,11 @@ export class MapPan extends Phaser.GameObjects.GameObject {
 	
 	preUpdate() {
 
-		Globals.panning = this.panKey.isDown || this.scene.input.activePointer.middleButtonDown();
-
 		const pointer = this.scene.input.activePointer;
+		
+		Globals.panning = this.panKey.isDown || pointer.middleButtonDown();
 
-		if (Globals.panning && this.isScrolling && this.active) {
+		if (Globals.panning && this.isScrolling && this.active && pointer.isDown) {
 			const dx = pointer.x - this.startMouse.x;
 			const dy = pointer.y - this.startMouse.y;
 			

--- a/webapp/src/app/shared/phaser/map-pan.ts
+++ b/webapp/src/app/shared/phaser/map-pan.ts
@@ -81,11 +81,7 @@ export class MapPan extends Phaser.GameObjects.GameObject {
 	
 	preUpdate() {
 
-		if (this.panKey.isDown || this.scene.input.activePointer.middleButtonDown()) {
-			Globals.panning = true;
-		} else {
-			Globals.panning = false;
-		}
+		Globals.panning = this.panKey.isDown || this.scene.input.activePointer.middleButtonDown();
 
 		const pointer = this.scene.input.activePointer;
 

--- a/webapp/src/app/shared/phaser/map-pan.ts
+++ b/webapp/src/app/shared/phaser/map-pan.ts
@@ -8,11 +8,13 @@ export class MapPan extends Phaser.GameObjects.GameObject {
 	private startCam: Point = {x: 0, y: 0};
 	
 	private zoomKey: Phaser.Input.Keyboard.Key;
+	private panKey: Phaser.Input.Keyboard.Key;
 	
 	constructor(scene: Phaser.Scene, type: string) {
 		super(scene, type);
 		
 		this.zoomKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ALT, false);
+		this.panKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.CTRL, false);
 		// game.input.mouseWheel.callback = (v) => this.onMouseWheel(v);
 		scene.input.on('wheel', (
 			pointer: Phaser.Input.Pointer,
@@ -29,6 +31,15 @@ export class MapPan extends Phaser.GameObjects.GameObject {
 		if (!this.active) {
 			return;
 		}
+
+		// set global panning state when the panKey is down
+		if (this.panKey.isDown || this.scene.input.activePointer.middleButtonDown()) {
+			Globals.panning = true;
+		} else {
+			Globals.panning = false;
+			return;
+		}
+
 		this.isScrolling = true;
 		const cam = this.scene.cameras.main;
 		Vec2.assign(this.startMouse, this.scene.input.activePointer);
@@ -69,8 +80,16 @@ export class MapPan extends Phaser.GameObjects.GameObject {
 	}
 	
 	preUpdate() {
+
+		if (this.panKey.isDown || this.scene.input.activePointer.middleButtonDown()) {
+			Globals.panning = true;
+		} else {
+			Globals.panning = false;
+		}
+
 		const pointer = this.scene.input.activePointer;
-		if (pointer.middleButtonDown() && this.isScrolling && this.active) {
+
+		if (Globals.panning && this.isScrolling && this.active) {
 			const dx = pointer.x - this.startMouse.x;
 			const dy = pointer.y - this.startMouse.y;
 			

--- a/webapp/src/app/shared/phaser/tilemap/tile-drawer.ts
+++ b/webapp/src/app/shared/phaser/tilemap/tile-drawer.ts
@@ -156,6 +156,12 @@ export class TileDrawer extends BaseObject {
 			if (this.lastDraw.x === p.x && this.lastDraw.y === p.y) {
 				return;
 			}
+
+			// skip drawing if panning key is down
+			if (Globals.panning) {
+				return;
+			}
+
 			this.dirty = true;
 			for (const tile of this.selectedTiles) {
 				


### PR DESCRIPTION
Adds `SHIFT` as a control to pan the camera,  allowing a user working on a touch pad to perform the already existing zoom (ALT + two finger zoom) and what this pull request covers, to pan ( SHIFT + mouse click finger move) 