### PR TITLE
Allow forked repos to run github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,8 @@
 name: build
 on:
-  push:
-    branches-ignore:
-      - master
+  # https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/13
+  workflow_dispatch:
   pull_request:
-    branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-      # source: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
-      - '**:**'
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
run build on all pull requests so it also includes forked repos (untested, because i don't know how to fork my own fork)
https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/13