### PR TITLE
Set contextIsolation to false for future updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+### Fixed
+- Fixed crashes on startup when upgrading Electron.
+
 ## [0.10.1] 2021-04-04
 
 ### Changed

--- a/webapp/main.js
+++ b/webapp/main.js
@@ -34,7 +34,8 @@ function openWindow() {
 			webPreferences: {
 				webSecurity: false,
 				nodeIntegration: true,
-				enableRemoteModule: true
+				enableRemoteModule: true,
+				contextIsolation: false
 			}
 		});
 		


### PR DESCRIPTION
According to [this link](https://www.electronjs.org/docs/breaking-changes#default-changed-contextisolation-defaults-to-true) `contextIsolation` will be set to `true` by default in Electron 12 which will remove `require` from the renderer's scope.

This PR sets `contextIsolation` to `false` explicitly to avoid future bugs.