### PR TITLE
Solve issue 188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+### Added
+- Full event editor support for `quest`, `shop`, `arena` and `trade` events
+
 ## [0.12.0] 2021-10-05
 
 ### Added

--- a/webapp/src/app/models/events.ts
+++ b/webapp/src/app/models/events.ts
@@ -36,7 +36,7 @@ export type EventArray =
 	{trade: TraderEvent}
 ;
 
-export function destructureEventArray(events: EventArray): {events?: EventType[], type: EventArrayType, trader?: string} {
+export function destructureEventArray(events: EventArray): {events: EventType[], type: EventArrayType, trader?: string} {
 	if (Array.isArray(events)) {
 		return {events: events, type: EventArrayType.Simple};
 	} else if ('quest' in events) {
@@ -48,7 +48,7 @@ export function destructureEventArray(events: EventArray): {events?: EventType[]
 	} else if ('trade' in events) {
 		const event = events.trade.event;
 		return {
-			events: event === undefined ? undefined : (event.length > 0 ? event : undefined),
+			events: event ?? [],
 			type: EventArrayType.Trade,
 			trader: events.trade.trader
 		};

--- a/webapp/src/app/models/events.ts
+++ b/webapp/src/app/models/events.ts
@@ -1,3 +1,5 @@
+import { EventType } from '../shared/widgets/event-widget/event-registry/abstract-event';
+
 export interface Person {
 	person: string;
 	expression: string;
@@ -11,4 +13,64 @@ export interface Label {
 	ja_JP: string;
 	ko_KR: string;
 	langUid: number;
+}
+
+export enum EventArrayType {
+	Simple = 'simple',
+	Quest = 'quest',
+	Shop = 'shop',
+	Arena = 'arena',
+	Trade = 'trade'
+}
+
+export interface TraderEvent {
+	event: EventType[];
+	trader?: string; //Maps have it but it's a pain to handle type set and trader set at the same time in the UI
+}
+
+export type EventArray = 
+	EventType[] |
+	{quest: EventType[]} |
+	{shop: EventType[]} |
+	{arena: EventType[]} |
+	{trade: TraderEvent}
+;
+
+export function destructureEventArray(events: EventArray): {events: EventType[], type: EventArrayType, trader?: string} {
+	if (Array.isArray(events)) {
+		return {events: events, type: EventArrayType.Simple};
+	} else if ('quest' in events) {
+		return {events: events.quest, type: EventArrayType.Quest};
+	} else if ('shop' in events) {
+		return {events: events.shop, type: EventArrayType.Shop};
+	} else if ('arena' in events) {
+		return {events: events.arena, type: EventArrayType.Arena};
+	} else if ('trade' in events) {
+		return {events: events.trade.event, type: EventArrayType.Trade, trader: events.trade.trader};
+	}
+	throw new TypeError('Argument passed to ' + destructureEventArray.name + ' is not of type EventArray.');
+}
+
+/**
+ * 
+ * @param events 
+ * @param type 
+ * @param trader Required only when `type` is `Trade`
+ * @returns 
+ */
+export function createEventArray(events: EventType[], type: EventArrayType, trader?: string): EventArray {
+	switch (type) {
+	case 'simple': return events;
+	case 'arena': return {arena: events};
+	case 'quest': return {quest: events};
+	case 'shop': return {shop: events};
+	case 'trade':
+		return {
+			trade: {
+				event: events,
+				trader: trader
+			}
+		};
+	default: return [];
+	}
 }

--- a/webapp/src/app/models/events.ts
+++ b/webapp/src/app/models/events.ts
@@ -24,7 +24,7 @@ export enum EventArrayType {
 }
 
 export interface TraderEvent {
-	event: EventType[];
+	event?: EventType[];
 	trader?: string; //Maps have it but it's a pain to handle type set and trader set at the same time in the UI
 }
 
@@ -36,7 +36,7 @@ export type EventArray =
 	{trade: TraderEvent}
 ;
 
-export function destructureEventArray(events: EventArray): {events: EventType[], type: EventArrayType, trader?: string} {
+export function destructureEventArray(events: EventArray): {events?: EventType[], type: EventArrayType, trader?: string} {
 	if (Array.isArray(events)) {
 		return {events: events, type: EventArrayType.Simple};
 	} else if ('quest' in events) {
@@ -67,7 +67,7 @@ export function createEventArray(events: EventType[], type: EventArrayType, trad
 	case 'trade':
 		return {
 			trade: {
-				event: events,
+				event: events.length > 0? events : undefined,
 				trader: trader
 			}
 		};

--- a/webapp/src/app/models/events.ts
+++ b/webapp/src/app/models/events.ts
@@ -46,18 +46,16 @@ export function destructureEventArray(events: EventArray): {events?: EventType[]
 	} else if ('arena' in events) {
 		return {events: events.arena, type: EventArrayType.Arena};
 	} else if ('trade' in events) {
-		return {events: events.trade.event, type: EventArrayType.Trade, trader: events.trade.trader};
+		const event = events.trade.event;
+		return {
+			events: event === undefined ? undefined : (event.length > 0 ? event : undefined),
+			type: EventArrayType.Trade,
+			trader: events.trade.trader
+		};
 	}
 	throw new TypeError('Argument passed to ' + destructureEventArray.name + ' is not of type EventArray.');
 }
 
-/**
- * 
- * @param events 
- * @param type 
- * @param trader Required only when `type` is `Trade`
- * @returns 
- */
 export function createEventArray(events: EventType[], type: EventArrayType, trader?: string): EventArray {
 	switch (type) {
 	case 'simple': return events;
@@ -71,6 +69,6 @@ export function createEventArray(events: EventType[], type: EventArrayType, trad
 				trader: trader
 			}
 		};
-	default: return [];
+	default: throw new TypeError(`'type' argument passed to ${createEventArray.name} must be of type EventArrayType. Received ${type} instead.`);
 	}
 }

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -72,13 +72,9 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	ngOnChanges() {
 		const eventCopy: EventArray = JSON.parse(JSON.stringify(this.eventData));
 		const destructuredEvents = destructureEventArray(eventCopy);
-		if (destructuredEvents !== undefined) {
-			this.inputtedEventType = destructuredEvents.type;
-		} else {
-			console.error('Loaded map has invalid format.');
-		}
 		
-		this.workingData = destructuredEvents.events.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep));
+		this.inputtedEventType = destructuredEvents.type;
+		this.workingData = destructuredEvents.events?.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep)) ?? [];
 		
 		this.refreshAll();
 	}

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -28,7 +28,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	@Input() eventData: EventArray | unknown = [];
 	@Input() actionStep = false;
 	
-	@Output() eventsChanged = new EventEmitter<EventArray>();
+	@Output() eventsChanged = new EventEmitter<EventType[]>();
 	
 	get base() {
 		return EventEditorComponent.globalBase;
@@ -114,8 +114,11 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	}
 	
 	export(eventType?: EventArrayType, trader?: string): EventArray {
-		const exportedArray = this.workingData.map(event => event.export());
-		return createEventArray(exportedArray, eventType ?? this.inputtedEventType, trader ?? this.inputtedTrader);
+		return createEventArray(this.exportRaw(), eventType ?? this.inputtedEventType, trader ?? this.inputtedTrader);
+	}
+	
+	exportRaw() {
+		return this.workingData.map(event => event.export());		
 	}
 	
 	drop(event: CdkDragDrop<EventDisplay>) {
@@ -365,7 +368,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 			this.select(node);
 		}
 		this.detailsShown = shown;
-		this.eventsChanged.emit(this.export());
+		this.eventsChanged.emit(this.exportRaw());
 	}
 	
 	private getIndex(event: EventDisplay | null | undefined) {

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -71,11 +71,18 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	
 	ngOnChanges() {
 		const eventCopy: EventArray = JSON.parse(JSON.stringify(this.eventData));
-		const destructuredEvents = destructureEventArray(eventCopy);
-		
-		this.inputtedEventType = destructuredEvents.type;
-		this.workingData = destructuredEvents.events?.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep)) ?? [];
-		
+		try {
+			const destructuredEvents = destructureEventArray(eventCopy);
+			this.inputtedEventType = destructuredEvents.type;
+			this.workingData = destructuredEvents.events?.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep)) ?? [];
+		} catch (destructuringError) {
+			this.workingData = [];
+			if (destructuringError instanceof TypeError) {
+				console.error(`Error while reading map, invalid format. Using empty array as default.\n\nException:\n${destructuringError.stack}`);
+			} else {
+				throw destructuringError;
+			}
+		}
 		this.refreshAll();
 	}
 	
@@ -106,7 +113,6 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	export(): EventArray {
 		const exportedArray = this.workingData.map(event => event.export());
 		return createEventArray(exportedArray, this.exportedEventType ?? this.inputtedEventType, this.trader);
-		//return this.workingData?.map(event => event.export()) ?? this.eventData;
 	}
 	
 	drop(event: CdkDragDrop<EventDisplay>) {

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -82,7 +82,8 @@ export class EventEditorComponent implements OnChanges, OnInit {
 			if (destructuringError instanceof TypeError) {
 				console.error(`Error while reading events, invalid format. Using empty event array as fallback.\n\nException:\n${destructuringError.stack}`);
 			} else {
-				throw destructuringError;
+				console.error('Unknown exception while reading events. Using empty event array as fallback.\n\nException in message below.');
+				console.error(destructuringError);
 			}
 		}
 		this.refreshAll();

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, ElementRef, Input, OnChanges, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { AbstractEvent, EventType } from '../../event-registry/abstract-event';
+import { EventArray, EventArrayType, destructureEventArray, createEventArray } from '../../../../../models/events';
 import { EventHelperService } from '../event-helper.service';
 import { FlatTreeControl } from '@angular/cdk/tree';
 import { CdkDrag, CdkDragDrop, CdkDropList } from '@angular/cdk/drag-drop';
@@ -24,8 +25,10 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	@ViewChild('eventDetail', {static: true}) eventDetail?: unknown; //EventDetailComponent but it errors for some reason
 	@ViewChild('eventTree', {read: ElementRef}) eventTree?: ElementRef<HTMLElement>;
 	
-	@Input() eventData: EventType[] = [];
+	@Input() eventData: EventArray | unknown = [];
 	@Input() actionStep = false;
+	@Input() exportedEventType?: EventArrayType;
+	@Input() trader?: string;
 	
 	get base() {
 		return EventEditorComponent.globalBase;
@@ -36,6 +39,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	
 	detailsShown = false;
 	wrapText!: boolean;
+	inputtedEventType: EventArrayType = EventArrayType.Simple;
 	
 	treeControl = new FlatTreeControl<EventDisplay>(e => e.level, e => e.children != null);
 	private treeFlattener = new MatTreeFlattener(
@@ -49,7 +53,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
 	
 	private history = new EventHistory();
-	private workingData!: AbstractEvent<any>[];
+	private workingData: AbstractEvent<any>[] = [];
 	private selectedNode?: EventDisplay;
 	private shownNode?: EventDisplay;
 	private copiedNode?: EventDisplay;
@@ -66,16 +70,16 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	}
 	
 	ngOnChanges() {
-		let cpy = JSON.parse(JSON.stringify(this.eventData));
-		if (!cpy.map) {
-			// TODO: find out how to properly handle quests
-			cpy = cpy.quest;
-		}
-		if (cpy.map) {
-			this.workingData = cpy.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep));
+		const eventCopy: EventArray = JSON.parse(JSON.stringify(this.eventData));
+		const destructuredEvents = destructureEventArray(eventCopy);
+		if (destructuredEvents !== undefined) {
+			this.inputtedEventType = destructuredEvents.type;
 		} else {
-			this.workingData = [];
+			console.error('Loaded map has invalid format.');
 		}
+		
+		this.workingData = destructuredEvents.events.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep));
+		
 		this.refreshAll();
 	}
 	
@@ -103,8 +107,10 @@ export class EventEditorComponent implements OnChanges, OnInit {
 		this.detailsShown = false;
 	}
 	
-	export() {
-		return this.workingData?.map(event => event.export()) ?? this.eventData;
+	export(): EventArray {
+		const exportedArray = this.workingData.map(event => event.export());
+		return createEventArray(exportedArray, this.exportedEventType ?? this.inputtedEventType, this.trader);
+		//return this.workingData?.map(event => event.export()) ?? this.eventData;
 	}
 	
 	drop(event: CdkDragDrop<EventDisplay>) {

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnChanges, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, Output, OnChanges, OnInit, OnDestroy, ViewChild, EventEmitter } from '@angular/core';
 import { AbstractEvent, EventType } from '../../event-registry/abstract-event';
 import { EventArray, EventArrayType, destructureEventArray, createEventArray } from '../../../../../models/events';
 import { EventHelperService } from '../event-helper.service';
@@ -27,6 +27,8 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	
 	@Input() eventData: EventArray | unknown = [];
 	@Input() actionStep = false;
+	
+	@Output() eventsChanged = new EventEmitter<EventArray>();
 	
 	get base() {
 		return EventEditorComponent.globalBase;
@@ -362,6 +364,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 			this.select(node);
 		}
 		this.detailsShown = shown;
+		this.eventsChanged.emit(this.export());
 	}
 	
 	private getIndex(event: EventDisplay | null | undefined) {

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -27,8 +27,6 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	
 	@Input() eventData: EventArray | unknown = [];
 	@Input() actionStep = false;
-	@Input() exportedEventType?: EventArrayType;
-	@Input() trader?: string;
 	
 	get base() {
 		return EventEditorComponent.globalBase;
@@ -39,7 +37,6 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	
 	detailsShown = false;
 	wrapText!: boolean;
-	inputtedEventType: EventArrayType = EventArrayType.Simple;
 	
 	treeControl = new FlatTreeControl<EventDisplay>(e => e.level, e => e.children != null);
 	private treeFlattener = new MatTreeFlattener(
@@ -57,6 +54,8 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	private selectedNode?: EventDisplay;
 	private shownNode?: EventDisplay;
 	private copiedNode?: EventDisplay;
+	private inputtedEventType: EventArrayType = EventArrayType.Simple;
+	private inputtedTrader?: string;
 	
 	constructor(
 		private helper: EventHelperService,
@@ -74,6 +73,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 		try {
 			const destructuredEvents = destructureEventArray(eventCopy);
 			this.inputtedEventType = destructuredEvents.type;
+			this.inputtedTrader = destructuredEvents.trader;
 			this.workingData = destructuredEvents.events?.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep)) ?? [];
 		} catch (destructuringError) {
 			this.workingData = [];
@@ -110,9 +110,9 @@ export class EventEditorComponent implements OnChanges, OnInit {
 		this.detailsShown = false;
 	}
 	
-	export(): EventArray {
+	export(eventType?: EventArrayType, trader?: string): EventArray {
 		const exportedArray = this.workingData.map(event => event.export());
-		return createEventArray(exportedArray, this.exportedEventType ?? this.inputtedEventType, this.trader);
+		return createEventArray(exportedArray, eventType ?? this.inputtedEventType, trader ?? this.inputtedTrader);
 	}
 	
 	drop(event: CdkDragDrop<EventDisplay>) {

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -80,7 +80,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 		} catch (destructuringError) {
 			this.workingData = [];
 			if (destructuringError instanceof TypeError) {
-				console.error(`Error while reading map, invalid format. Using empty array as default.\n\nException:\n${destructuringError.stack}`);
+				console.error(`Error while reading events, invalid format. Using empty event array as fallback.\n\nException:\n${destructuringError.stack}`);
 			} else {
 				throw destructuringError;
 			}

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -56,8 +56,6 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	private selectedNode?: EventDisplay;
 	private shownNode?: EventDisplay;
 	private copiedNode?: EventDisplay;
-	private inputtedEventType: EventArrayType = EventArrayType.Simple;
-	private inputtedTrader?: string;
 	
 	constructor(
 		private helper: EventHelperService,
@@ -73,10 +71,8 @@ export class EventEditorComponent implements OnChanges, OnInit {
 	ngOnChanges() {
 		const eventCopy: EventArray = JSON.parse(JSON.stringify(this.eventData));
 		try {
-			const destructuredEvents = destructureEventArray(eventCopy);
-			this.inputtedEventType = destructuredEvents.type;
-			this.inputtedTrader = destructuredEvents.trader;
-			this.workingData = destructuredEvents.events?.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep)) ?? [];
+			const {events} = destructureEventArray(eventCopy);
+			this.workingData = events?.map((val: EventType) => this.helper.getEventFromType(val, this.actionStep)) ?? [];
 		} catch (destructuringError) {
 			this.workingData = [];
 			if (destructuringError instanceof TypeError) {
@@ -113,12 +109,8 @@ export class EventEditorComponent implements OnChanges, OnInit {
 		this.detailsShown = false;
 	}
 	
-	export(eventType?: EventArrayType, trader?: string): EventArray {
-		return createEventArray(this.exportRaw(), eventType ?? this.inputtedEventType, trader ?? this.inputtedTrader);
-	}
-	
-	exportRaw() {
-		return this.workingData.map(event => event.export());		
+	export(): EventType[] {
+		return this.workingData.map(event => event.export());
 	}
 	
 	drop(event: CdkDragDrop<EventDisplay>) {
@@ -368,7 +360,7 @@ export class EventEditorComponent implements OnChanges, OnInit {
 			this.select(node);
 		}
 		this.detailsShown = shown;
-		this.eventsChanged.emit(this.exportRaw());
+		this.eventsChanged.emit(this.export());
 	}
 	
 	private getIndex(event: EventDisplay | null | undefined) {

--- a/webapp/src/app/shared/widgets/event-widget/event-window/event-window.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-window/event-window.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter, ViewChild } from '@angular/core';
 import { EventEditorComponent } from '../event-editor/editor/event-editor.component';
 import { EventHelperService } from '../event-editor/event-helper.service';
-import { EventType } from '../event-registry/abstract-event';
+import { EventArray } from '../../../../models/events';
 
 @Component({
 	selector: 'app-event-window',
@@ -12,9 +12,9 @@ export class EventWindowComponent {
 
 	@ViewChild('eventEditor', { static: false }) eventEditor!: EventEditorComponent;
 
-	@Input() event!: EventType[];
+	@Input() event: EventArray | unknown = [];
 	@Input() actionStep = false;
-	@Output() exit = new EventEmitter<EventType[]>();
+	@Output() exit = new EventEmitter<EventArray>();
 
 	constructor(
 		private helper: EventHelperService

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states-widget.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states-widget.component.ts
@@ -4,6 +4,7 @@ import {NpcStatesComponent} from './npc-states/npc-states.component';
 import {OverlayService} from '../../overlay/overlay.service';
 import {OverlayRefControl} from '../../overlay/overlay-ref-control';
 import {Overlay} from '@angular/cdk/overlay';
+import {EventArray} from '../../../models/events';
 
 export interface NPCState {
 	reactType: string;
@@ -19,7 +20,7 @@ export interface NPCState {
 	};
 	condition: string;
 	config: string;
-	event: any;
+	event: EventArray;
 }
 
 @Component({

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
@@ -32,7 +32,7 @@
 					</div>
 				</div>
 				<div fxFlex="1 1 0" fxLayout="row" class="middle-container tab-content-inner">
-					<div class="content-left" fxFlex="0 0 200px" fxLayout="column">
+					<div class="content-left" fxFlex="0 0 225px" fxLayout="column">
 						
 						<!-- Position -->
 						<div fxFlex="0 0 auto">
@@ -108,6 +108,7 @@
 						<!-- Event Editor -->
 						<app-event-editor #eventEditor class="event-block" fxLayout="column"
 						                  [eventData]="currentState.event"
+										  (eventsChanged)="updateEventWarnings($event)"
 										  ></app-event-editor>
 					</div>
 				</div>

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
@@ -75,7 +75,7 @@
 						<!-- Event type -->
 						<div fxLayout="row" class="attribute" fxFlex="0 0 auto">
 							<span fxFlex="0 0 87px" fxFlexAlign="center">Event type: </span>
-							<select class="default-input select-input" [(ngModel)]="currentEventType">
+							<select class="default-input select-input" [(ngModel)]="eventType">
 								<option *ngFor="let type of eventTypes" [value]="type">
 									{{type}}
 								</option>
@@ -99,18 +99,16 @@
 						</div>
 						
 						<!-- Warnings -->
-						<div>
-							<div fxLayout="row" class="warning-message" *ngFor="let warning of warnings">
-								<mat-icon>warning</mat-icon>
-								<span fxFlexAlign="center">{{warning}}</span>
-							</div>
+						<div fxLayout="row" class="warning-message" *ngFor="let warning of warnings">
+							<mat-icon>warning</mat-icon>
+							<span fxFlexAlign="center">{{warning}}</span>
 						</div>
 					</div>
 					<div fxFlex="1 1 0" fxLayout="column" class="event-container">
 						<!-- Event Editor -->
 						<app-event-editor #eventEditor class="event-block" fxLayout="column"
 						                  [eventData]="currentState.event"
-										  [exportedEventType]="currentEventType"
+										  [exportedEventType]="eventType"
 										  [trader]="trader"
 										  ></app-event-editor>
 					</div>

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
@@ -108,8 +108,6 @@
 						<!-- Event Editor -->
 						<app-event-editor #eventEditor class="event-block" fxLayout="column"
 						                  [eventData]="currentState.event"
-										  [exportedEventType]="eventType"
-										  [trader]="trader"
 										  ></app-event-editor>
 					</div>
 				</div>

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
@@ -75,7 +75,7 @@
 						<!-- Event type -->
 						<div fxLayout="row" class="attribute" fxFlex="0 0 auto">
 							<span fxFlex="0 0 87px" fxFlexAlign="center">Event type: </span>
-							<select class="default-input select-input" [(ngModel)]="eventType">
+							<select class="default-input select-input" [(ngModel)]="eventType" (ngModelChange)="updateDisplayedWarnings()">
 								<option *ngFor="let type of eventTypes" [value]="type">
 									{{type}}
 								</option>
@@ -85,7 +85,7 @@
 						<!-- Trader -->
 						<div *ngIf="isTradeEvent" fxLayout="row" class="attribute" fxFlex="0 0 auto">
 							<span fxFlex="0 0 87px" fxFlexAlign="center">Trader: </span>
-							<input class="default-input" [(ngModel)]="trader">
+							<input class="default-input" [(ngModel)]="trader" (ngModelChange)="updateDisplayedWarnings()">
 						</div>
 						
 						<!-- Other -->
@@ -108,7 +108,7 @@
 						<!-- Event Editor -->
 						<app-event-editor #eventEditor class="event-block" fxLayout="column"
 						                  [eventData]="currentState.event"
-						                  (eventsChanged)="updateEventWarnings($event)"
+						                  (eventsChanged)="updateTradeEventWarning($event)"
 						                  ></app-event-editor>
 					</div>
 				</div>

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
@@ -108,8 +108,8 @@
 						<!-- Event Editor -->
 						<app-event-editor #eventEditor class="event-block" fxLayout="column"
 						                  [eventData]="currentState.event"
-										  (eventsChanged)="updateEventWarnings($event)"
-										  ></app-event-editor>
+						                  (eventsChanged)="updateEventWarnings($event)"
+						                  ></app-event-editor>
 					</div>
 				</div>
 			</div>

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.html
@@ -72,6 +72,22 @@
 							<input class="default-input" [(ngModel)]="currentState.pageName">
 						</div>
 						
+						<!-- Event type -->
+						<div fxLayout="row" class="attribute" fxFlex="0 0 auto">
+							<span fxFlex="0 0 87px" fxFlexAlign="center">Event type: </span>
+							<select class="default-input select-input" [(ngModel)]="currentEventType">
+								<option *ngFor="let type of eventTypes" [value]="type">
+									{{type}}
+								</option>
+							</select>
+						</div>
+						
+						<!-- Trader -->
+						<div *ngIf="isTradeEvent" fxLayout="row" class="attribute" fxFlex="0 0 auto">
+							<span fxFlex="0 0 87px" fxFlexAlign="center">Trader: </span>
+							<input class="default-input" [(ngModel)]="trader">
+						</div>
+						
 						<!-- Other -->
 						<div *ngFor="let prop of props | keyvalue" fxLayout="row" class="attribute" fxFlex="0 0 auto">
 							<span fxFlex="0 0 87px" fxFlexAlign="center">{{prop.key}}: </span>
@@ -81,11 +97,22 @@
 								</option>
 							</select>
 						</div>
+						
+						<!-- Warnings -->
+						<div>
+							<div fxLayout="row" class="warning-message" *ngFor="let warning of warnings">
+								<mat-icon>warning</mat-icon>
+								<span fxFlexAlign="center">{{warning}}</span>
+							</div>
+						</div>
 					</div>
 					<div fxFlex="1 1 0" fxLayout="column" class="event-container">
 						<!-- Event Editor -->
 						<app-event-editor #eventEditor class="event-block" fxLayout="column"
-						                  [eventData]="currentState.event"></app-event-editor>
+						                  [eventData]="currentState.event"
+										  [exportedEventType]="currentEventType"
+										  [trader]="trader"
+										  ></app-event-editor>
 					</div>
 				</div>
 			</div>

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.scss
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.scss
@@ -86,6 +86,7 @@ $accent: map-get($theme, accent);
 }
 
 .warning-message {
+	margin-bottom: 14px;
 	& > mat-icon {
 		color: orange;
 		margin-right: 4px;

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.scss
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.scss
@@ -85,7 +85,9 @@ $accent: map-get($theme, accent);
 	min-width: 0;
 }
 
-.warning-message > mat-icon {
-	color: orange;
-	margin-right: 4px;
+.warning-message {
+	& > mat-icon {
+		color: orange;
+		margin-right: 4px;
+	}
 }

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.scss
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.scss
@@ -84,3 +84,8 @@ $accent: map-get($theme, accent);
 .event-container {
 	min-width: 0;
 }
+
+.warning-message > mat-icon {
+	color: orange;
+	margin-right: 4px;
+}

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -116,7 +116,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 			throw new Error('event editor is not defined');
 		}
 		if (this.currentState) {
-			this.currentState.event = this.eventEditor.export();
+			this.currentState.event = this.eventEditor.export(this.eventType, this.trader);
 		}
 		const out = this.states;
 		out.forEach(state => {

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -19,8 +19,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 	
 	props = settingsJson.default;
 	warnings: string[] = [];
-	missingTradeEvent = false;
-	positionActive = false;
+	private missingTradeEvent = false;
 	
 	eventType: EventArrayType = EventArrayType.Simple;
 	trader?: string;
@@ -66,9 +65,6 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 			this.eventEditor.show();
 		}
 		this.currentState = this.states[index];
-		
-		const active = this.currentState && this.currentState.position && this.currentState.position.active;
-		this.positionActive = !!active;
 		this.index = index;
 		({type: this.eventType, trader: this.trader} = destructureEventArray(this.currentState.event));
 	}
@@ -143,7 +139,6 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 	}
 	
 	updateEventWarnings(updatedEvents: EventArray) {
-		//TODO: warning is still visible when changing event type to a different kind from trade.
 		function hasEventOfTypeRecursive(object: any, type: string): boolean {
 			if (typeof object !== 'object') {
 				return false;

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -142,7 +142,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 	
 	updateEventWarnings(updatedEvents: EventType[]) {
 		function hasEventOfTypeRecursive(object: any, type: string): boolean {
-			if (typeof object !== 'object') {
+			if (typeof object !== 'object' || object === null) {
 				return false;
 			}
 			for (const key of Object.keys(object)) {

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -98,7 +98,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 		if (!this.eventEditor) {
 			throw new Error('event editor is not defined');
 		}
-		this.currentState.event = this.eventEditor.export();
+		this.currentState.event = createEventArray(this.eventEditor.export(), this.eventType, this.trader);
 		this.clipboard = JSON.stringify(this.currentState);
 		console.log(JSON.parse(this.clipboard));
 	}

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -145,7 +145,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 	set currentEventType(newType: EventArrayType) {
 		const currentEvent = destructureEventArray(this.currentState!.event);
 		if (currentEvent.type !== newType) {
-			this.currentState!.event = createEventArray(currentEvent.events, newType, this.trader);
+			this.currentState!.event = createEventArray(currentEvent.events ?? [], newType, this.trader);
 		}
 	}
 	

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -58,7 +58,9 @@ export class NpcStatesComponent implements OnInit {
 		}
 		this.currentState = this.states[index];
 		this.index = index;
-		({type: this.eventType, trader: this.trader} = destructureEventArray(this.currentState.event));
+		if (this.currentState) { //Undefined if this.states.length is 0
+			({type: this.eventType, trader: this.trader} = destructureEventArray(this.currentState.event));
+		}
 	}
 	
 	newPage() {

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -63,7 +63,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 			if (!this.eventEditor) {
 				throw new Error('event editor is not defined');
 			}
-			this.currentState.event = this.eventEditor.export(this.eventType, this.trader);
+			this.currentState.event = createEventArray(this.eventEditor.export(), this.eventType, this.trader);
 			this.eventEditor.show();
 		}
 		this.currentState = this.states[index];
@@ -118,7 +118,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 			throw new Error('event editor is not defined');
 		}
 		if (this.currentState) {
-			this.currentState.event = this.eventEditor.export(this.eventType, this.trader);
+			this.currentState.event = createEventArray(this.eventEditor.export(), this.eventType, this.trader);
 		}
 		const out = this.states;
 		out.forEach(state => {

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -18,8 +18,11 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 	index = 0;
 	
 	props = settingsJson.default;
-	warnings: string[] = ['A test warning'];
+	warnings: string[] = [];
 	positionActive = false;
+	
+	eventType: EventArrayType = EventArrayType.Simple;
+	trader?: string;
 	
 	// TODO: move to global events service
 	clipboard = '';
@@ -63,6 +66,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 		const active = this.currentState && this.currentState.position && this.currentState.position.active;
 		this.positionActive = !!active;
 		this.index = index;
+		({type: this.eventType, trader: this.trader} = destructureEventArray(this.currentState.event));
 	}
 	
 	newPage() {
@@ -134,41 +138,13 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 		this.exit.error('cancel');
 	}
 	
+	}
+	
 	get isTradeEvent() {
-		return this.currentEventType === EventArrayType.Trade;
-	}
-	
-	get currentEventType(): EventArrayType {
-		return destructureEventArray(this.currentState!.event).type;
-	}
-	
-	set currentEventType(newType: EventArrayType) {
-		const currentEvent = destructureEventArray(this.currentState!.event);
-		if (currentEvent.type !== newType) {
-			this.currentState!.event = createEventArray(currentEvent.events ?? [], newType, this.trader);
-		}
-	}
-	
-	get trader(): string | undefined {
-		const event = this.currentState!.event;
-		return 'trade' in event ? event.trade.trader : undefined;
-	}
-	
-	set trader(trader: string | undefined) {
-		const event = this.currentState!.event;
-		if ('trade' in event) {
-			event.trade.trader = trader;
-		} else {
-			console.warn(`Attempted to set "trader" property on event of type "${destructureEventArray(event).type}". Failing silently.`);
-		}
+		return this.eventType === EventArrayType.Trade;
 	}
 	
 	get eventTypes(): string[] {
-		const values = [];
-		// eslint-disable-next-line guard-for-in
-		for (const type in EventArrayType) {
-			values.push((EventArrayType as any)[type]);
-		}
-		return values;
+		return Object.keys(EventArrayType).map(name => (EventArrayType as any)[name]);
 	}
 }

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -3,6 +3,7 @@ import {NPCState} from '../npc-states-widget.component';
 import * as settingsJson from '../../../../../assets/npc-settings.json';
 import {EventEditorComponent} from '../../event-widget/event-editor/editor/event-editor.component';
 import {destructureEventArray, createEventArray, EventArray, EventArrayType} from '../../../../models/events';
+import { EventType } from '../../event-widget/event-registry/abstract-event';
 
 @Component({
 	selector: 'app-npc-states',
@@ -138,7 +139,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 		this.exit.error('cancel');
 	}
 	
-	updateEventWarnings(updatedEvents: EventArray) {
+	updateEventWarnings(updatedEvents: EventType[]) {
 		function hasEventOfTypeRecursive(object: any, type: string): boolean {
 			if (typeof object !== 'object') {
 				return false;
@@ -150,10 +151,10 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 			}
 			return false;
 		}
-		const {events} = destructureEventArray(updatedEvents);
+		
 		this.missingTradeEvent =
-			events !== undefined &&
-			!hasEventOfTypeRecursive(events, 'START_NPC_TRADE_MENU');
+			updatedEvents.length > 0 &&
+			!hasEventOfTypeRecursive(updatedEvents, 'START_NPC_TRADE_MENU');
 	}
 	
 	get isTradeEvent() {

--- a/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
+++ b/webapp/src/app/shared/widgets/npc-states-widget/npc-states/npc-states.component.ts
@@ -19,6 +19,7 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 	index = 0;
 	
 	props = settingsJson.default;
+	eventTypes = Object.values(EventArrayType);
 	warnings: string[] = [];
 	private missingTradeEvent = false;
 	
@@ -159,9 +160,5 @@ export class NpcStatesComponent implements OnInit, DoCheck {
 	
 	get isTradeEvent() {
 		return this.eventType === EventArrayType.Trade;
-	}
-	
-	get eventTypes(): string[] {
-		return Object.keys(EventArrayType).map(name => (EventArrayType as any)[name]);
 	}
 }


### PR DESCRIPTION
Solves #188.
Add the ability to load `shop`, `arena` and `trade` events in the event editor and save them correctly (including `quest` events).
The event type can be specified in the side panel of NPC editing windows:
![Side panel](https://user-images.githubusercontent.com/56268917/139259764-77130aec-4495-478a-9bb8-7eba59440fd6.png)

Trade events add another property below the event type to specify the trader name:
![Trader name field](https://user-images.githubusercontent.com/56268917/139258816-a6b9d992-7b4d-4d8d-83fb-9de3e55ca028.png)

Trade events have a warning that pops up when a trader is not specified:
![Missing trader name warning](https://user-images.githubusercontent.com/56268917/139260127-f8d2e370-624f-4e25-bb16-1bf91a1ea0db.png)

There is also a warning if a trade event does not have a `START_NPC_TRADE_MENU` event:
![Missing start trade event warning](https://user-images.githubusercontent.com/56268917/139260911-6f91e4c2-0d0e-4d2d-84f7-17627ffb07d4.png)
The warning does not apper on traders with no events since the `START_NPC_TRADE_MENU` is not required if the trader has its `event` property not set and the editor exports traders with an empty event array as undefined.