### PR TITLE
Add branch display to `OPEN_QUEST_DIALOG` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Full event editor support for `quest`, `shop`, `arena` and `trade` events
+- Ability to view and edit `OPEN_QUEST_DIALOG` event branches
 
 ## [0.12.0] 2021-10-05
 

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/event-helper.service.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/event-helper.service.ts
@@ -30,6 +30,10 @@ export class EventHelperService {
 			valChoice.options.forEach((option: any, index: number) => {
 				valChoice[index] = valChoice[index].map((v: EventType) => this.getEventFromType(v, actionStep));
 			});
+		} else if (val.type === 'OPEN_QUEST_DIALOG') {
+			const valQuestDialog = val as any;
+			valQuestDialog.accepted = valQuestDialog.accepted.map((v: EventType) => this.getEventFromType(v, actionStep));
+			valQuestDialog.declined = valQuestDialog.declined.map((v: EventType) => this.getEventFromType(v, actionStep));
 		}
 		
 		instance.update();

--- a/webapp/src/app/shared/widgets/event-widget/event-registry/event-registry.service.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-registry/event-registry.service.ts
@@ -4,6 +4,7 @@ import {DefaultEvent} from './default-event';
 import {If} from './if';
 import {ShowMsg} from './show-msg';
 import {ShowChoice} from './ShowChoice';
+import {OpenQuestDialog} from './open-quest-dialogue';
 import {SetPlayerCore} from './set-player-core';
 import {ClearSlowMotion} from './clear-slow-motion';
 import {SetOverlay} from './set-overlay';
@@ -44,6 +45,7 @@ export class EventRegistryService {
 		this.register('WAIT', Wait);
 		this.register('LABEL', Label);
 		this.register('GOTO_LABEL', GotoLabel);
+		this.register('OPEN_QUEST_DIALOG', OpenQuestDialog);
 		
 	}
 	

--- a/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
@@ -71,14 +71,14 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 			npc: this.data.npc,
 			map: this.data.map,
 			
+			//Useless values (they don't do anything but keep them if the original event has them)
+			activate: this.data.activate,
+			acceptVar: this.data.acceptVar,
+			cancelVar: this.data.cancelVar,
+			
 			//Branches
 			accepted: this.data.accepted.map(v => v.export()),
 			declined: this.data.declined.map(v => v.export()),
-			
-			//Useless values (they don't do anything but keep them if the original event has them)
-			acceptVar: this.data.acceptVar,
-			cancelVar: this.data.cancelVar,
-			activate: this.data.activate,
 		};
 		return out;
 	}

--- a/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
@@ -1,0 +1,82 @@
+import { EntityAttributes } from '../../../phaser/entities/cc-entity';
+import {AbstractEvent, EventType} from './abstract-event';
+
+export interface OpenQuestDialogData extends EventType {
+	activate: boolean; //No idea what this does, but no quest has it set to true
+	quest: string;
+	acceptVar: string;
+	map: string;
+	npc: string;
+	accepted: AbstractEvent<any>[];
+	declined: AbstractEvent<any>[];
+}
+
+export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
+	private attributes: EntityAttributes = {
+		quest: {
+			type: 'Quest',
+			ignoreSubs: true,
+			description: 'The quest to open'
+		},
+		npc: {
+			type: 'Character',
+			optional: true,
+			description: 'Character to use as quest giver, override default and can be used in event triggers.'
+		},
+		map: {
+			type: 'Maps',
+			optional: true,
+			description: 'Map to show instead of the automated one'
+		}
+	};
+	
+	getAttributes(): EntityAttributes {
+		return this.attributes;
+	}
+	
+	update() {
+		this.children = [];
+		this.info = this.combineStrings(
+			this.getTypeString('#7ea3ff'),
+			this.getPropString('quest'),
+			this.getPropString('npc'),
+			this.getPropString('map')
+		);
+		
+		this.children[0] = {
+			title: this.getColoredString('Quest. Accepted', '#838383'),
+			events: this.data.accepted,
+			draggable: false
+		};
+		if (this.data.declined) {
+			this.children[1] = {
+				title: this.getColoredString('Quest. Declined', '#838383'),
+				events: this.data.declined,
+				draggable: false
+			};
+		}
+	}
+	
+	export(): OpenQuestDialogData {
+		const out: OpenQuestDialogData = {
+			type: this.data.type,
+			quest: this.data.quest,
+			acceptVar: this.data.acceptVar,
+			npc: this.data.npc,
+			map: this.data.map,
+			activate: false,
+			accepted: this.data.accepted.map(v => v.export()),
+			declined: this.data.declined?.map(v => v.export())
+		};
+		return out;
+	}
+	
+	protected generateNewDataInternal() {
+		return {
+			quest: '',
+			npc: undefined,
+			map: undefined,
+			activate: false //No idea what activate does, but no quest sets it to true
+		};
+	}
+}

--- a/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
@@ -2,11 +2,17 @@ import { EntityAttributes } from '../../../phaser/entities/cc-entity';
 import {AbstractEvent, EventType} from './abstract-event';
 
 export interface OpenQuestDialogData extends EventType {
-	activate: boolean; //No idea what this does, but no quest has it set to true
+	//Attributes
 	quest: string;
-	acceptVar: string;
-	map: string;
 	npc: string;
+	map: string;
+	
+	//Mistery values
+	acceptVar?: string; //Only map that uses a value that is not "tmp.accept" is edge-test, a testing map that the editor doesn't open properly (it uses "tmp.cancel" instead)
+	cancelVar?: string; //Only used in edge-test
+	activate: boolean; //No idea what this does, but no quest has it set to true, poking with it makes no difference either
+	
+	//Branches
 	accepted: AbstractEvent<any>[];
 	declined: AbstractEvent<any>[];
 }
@@ -27,6 +33,11 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 			type: 'Maps',
 			optional: true,
 			description: 'Map to show instead of the automated one'
+		},
+		acceptVar: {
+			type: 'String',
+			optional: true,
+			description: 'Typically set by quests to either blank or "tmp.accept"'
 		}
 	};
 	
@@ -35,7 +46,6 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 	}
 	
 	update() {
-		this.children = [];
 		this.info = this.combineStrings(
 			this.getTypeString('#7ea3ff'),
 			this.getPropString('quest'),
@@ -43,27 +53,28 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 			this.getPropString('map')
 		);
 		
-		this.children[0] = {
-			title: this.getColoredString('Quest. Accepted', '#838383'),
-			events: this.data.accepted,
-			draggable: false
-		};
-		if (this.data.declined) {
-			this.children[1] = {
+		this.children = [
+			{
+				title: this.getColoredString('Quest. Accepted', '#838383'),
+				events: this.data.accepted,
+				draggable: false
+			},
+			{
 				title: this.getColoredString('Quest. Declined', '#838383'),
 				events: this.data.declined,
 				draggable: false
-			};
-		}
+			}
+		];
 	}
 	
 	export(): OpenQuestDialogData {
 		const out: OpenQuestDialogData = {
 			type: this.data.type,
 			quest: this.data.quest,
-			acceptVar: this.data.acceptVar,
 			npc: this.data.npc,
 			map: this.data.map,
+			acceptVar: this.data.acceptVar,
+			cancelVar: this.data.cancelVar,
 			activate: false,
 			accepted: this.data.accepted.map(v => v.export()),
 			declined: this.data.declined?.map(v => v.export())
@@ -76,7 +87,13 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 			quest: '',
 			npc: undefined,
 			map: undefined,
-			activate: false //No idea what activate does, but no quest sets it to true
+			
+			acceptVar: 'tmp.accept',
+			cancelVar: undefined,
+			activate: false, //No idea what activate does, but no quest sets it to true
+			
+			accepted: [],
+			declined: [],
 		};
 	}
 }

--- a/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-registry/open-quest-dialogue.ts
@@ -1,20 +1,20 @@
-import { EntityAttributes } from '../../../phaser/entities/cc-entity';
+import {EntityAttributes} from '../../../phaser/entities/cc-entity';
 import {AbstractEvent, EventType} from './abstract-event';
 
 export interface OpenQuestDialogData extends EventType {
 	//Attributes
 	quest: string;
-	npc: string;
-	map: string;
-	
-	//Mistery values
-	acceptVar?: string; //Only map that uses a value that is not "tmp.accept" is edge-test, a testing map that the editor doesn't open properly (it uses "tmp.cancel" instead)
-	cancelVar?: string; //Only used in edge-test
-	activate: boolean; //No idea what this does, but no quest has it set to true, poking with it makes no difference either
+	npc?: string;
+	map?: string;
 	
 	//Branches
 	accepted: AbstractEvent<any>[];
 	declined: AbstractEvent<any>[];
+	
+	//Useless values (declared in map files but never used by game code)
+	acceptVar?: string; //Only map that uses a value that is not "tmp.accept" is edge-test, a testing map that the editor doesn't open properly (it uses "tmp.cancel" instead)
+	cancelVar?: string; //Only used in edge-test
+	activate?: boolean; //Set by quests either to false or undefined
 }
 
 export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
@@ -34,11 +34,6 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 			optional: true,
 			description: 'Map to show instead of the automated one'
 		},
-		acceptVar: {
-			type: 'String',
-			optional: true,
-			description: 'Typically set by quests to either blank or "tmp.accept"'
-		}
 	};
 	
 	getAttributes(): EntityAttributes {
@@ -70,14 +65,20 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 	export(): OpenQuestDialogData {
 		const out: OpenQuestDialogData = {
 			type: this.data.type,
-			quest: this.data.quest,
+			
+			//Attributes
+			quest: this.data.quest ?? '',
 			npc: this.data.npc,
 			map: this.data.map,
+			
+			//Branches
+			accepted: this.data.accepted.map(v => v.export()),
+			declined: this.data.declined.map(v => v.export()),
+			
+			//Useless values (they don't do anything but keep them if the original event has them)
 			acceptVar: this.data.acceptVar,
 			cancelVar: this.data.cancelVar,
-			activate: false,
-			accepted: this.data.accepted.map(v => v.export()),
-			declined: this.data.declined?.map(v => v.export())
+			activate: this.data.activate,
 		};
 		return out;
 	}
@@ -85,13 +86,6 @@ export class OpenQuestDialog extends AbstractEvent<OpenQuestDialogData> {
 	protected generateNewDataInternal() {
 		return {
 			quest: '',
-			npc: undefined,
-			map: undefined,
-			
-			acceptVar: 'tmp.accept',
-			cancelVar: undefined,
-			activate: false, //No idea what activate does, but no quest sets it to true
-			
 			accepted: [],
 			declined: [],
 		};


### PR DESCRIPTION
Solves #223.
Adds branch display to the `OPEN_QUEST_DIALOG` event:
![quest-branching](https://user-images.githubusercontent.com/56268917/140976375-a4f50f06-630d-4932-b0f4-f5586d466586.png)