### PR TITLE
Add branch display to `START_NPC_TRADE_MENU` events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Full event editor support for `quest`, `shop`, `arena` and `trade` events
+- Ability to view and edit `START_NPC_TRADE_MENU` event branches
+
+### Fixed
+- Changes in the number of choices of `SHOW_CHOICE` events now update the branches visible in the event editor immediately
 
 ## [0.12.0] 2021-10-05
 

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/detail/event-detail.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/detail/event-detail.component.ts
@@ -21,6 +21,8 @@ import { JsonWidgetComponent } from '../../../json-widget/json-widget.component'
 import { EventHelperService } from '../event-helper.service';
 import { Subscription } from 'rxjs';
 
+export type RefreshType = 'Node' | 'Full';
+
 @Component({
 	selector: 'app-event-detail',
 	templateUrl: './event-detail.component.html',
@@ -31,7 +33,7 @@ export class EventDetailComponent implements OnDestroy {
 	
 	@Input() event!: AbstractEvent<any>;
 	@Output() close = new EventEmitter<void>();
-	@Output() refresh = new EventEmitter<AbstractEvent<any>>();
+	@Output() refresh = new EventEmitter<RefreshType>();
 	
 	newData: any;
 	unknownObj?: { data: any };
@@ -113,7 +115,9 @@ export class EventDetailComponent implements OnDestroy {
 	
 	private update() {
 		this.event.data = this.unknownObj ? this.unknownObj.data : this.newData;
+		const previousChildCount = this.event.children.length;
 		this.event.update();
-		this.refresh.emit(this.event);
+		const childCount = this.event.children.length;
+		this.refresh.emit((childCount > 0 || previousChildCount !== childCount)? 'Full' : 'Node');
 	}
 }

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.html
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.html
@@ -44,7 +44,7 @@
 			</div>
 		</ng-container>
 		<ng-container ngProjectAs="right">
-			<app-event-detail #eventDetail (refresh)="refresh()" (close)="hideDetails()"></app-event-detail>
+			<app-event-detail #eventDetail (refresh)="refresh($event)" (close)="hideDetails()"></app-event-detail>
 		</ng-container>
 	</app-split-pane>
 </div>

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/editor/event-editor.component.ts
@@ -9,7 +9,7 @@ import { SplitPaneComponent } from '../../../../split-pane/split-pane.component'
 import { EventDisplay } from '../event-display.model';
 import { AddEventService } from '../add/add-event.service';
 import { EventHistory } from './event-history';
-import { EventDetailComponent } from '../detail/event-detail.component';
+import { EventDetailComponent, RefreshType } from '../detail/event-detail.component';
 import { SettingsService } from '../../../../settings.service';
 
 @Component({
@@ -94,12 +94,12 @@ export class EventEditorComponent implements OnChanges, OnInit {
 		return index < this.treeControl.dataNodes.length - 1;
 	}
 	
-	refresh() {
+	refresh(refreshType: RefreshType) {
 		if (this.shownNode) {
 			this.shownNode.text = this.shownNode.data?.info ?? ' ';
 			this.shownNode.changeDetector?.detectChanges();
 			
-			if (this.shownNode.children) {
+			if (refreshType === 'Full') {
 				this.refreshAll();
 			}
 		}

--- a/webapp/src/app/shared/widgets/event-widget/event-editor/event-helper.service.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-editor/event-helper.service.ts
@@ -30,6 +30,12 @@ export class EventHelperService {
 			valChoice.options.forEach((option: any, index: number) => {
 				valChoice[index] = valChoice[index].map((v: EventType) => this.getEventFromType(v, actionStep));
 			});
+		} else if (val.type === 'START_NPC_TRADE_MENU') {
+			const valTradeMenu = val as any;
+			if (valTradeMenu.withBranches) {
+				valTradeMenu.traded = (valTradeMenu.traded ?? []).map((v: EventType) => this.getEventFromType(v, actionStep));
+				valTradeMenu.canceled = (valTradeMenu.canceled ?? []).map((v: EventType) => this.getEventFromType(v, actionStep));
+			}
 		}
 		
 		instance.update();

--- a/webapp/src/app/shared/widgets/event-widget/event-registry/event-registry.service.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-registry/event-registry.service.ts
@@ -16,6 +16,7 @@ import {SetCameraPos} from './set-camera-pos';
 import {SetCameraBetween} from './set-camera-between';
 import {Label} from './label';
 import {GotoLabel} from './goto-label';
+import {StartNpcTradeMenu} from './start-npc-trade-menu';
 import {AbstractEvent, EventType} from './abstract-event';
 import {DomSanitizer} from '@angular/platform-browser';
 
@@ -44,6 +45,7 @@ export class EventRegistryService {
 		this.register('WAIT', Wait);
 		this.register('LABEL', Label);
 		this.register('GOTO_LABEL', GotoLabel);
+		this.register('START_NPC_TRADE_MENU', StartNpcTradeMenu);
 		
 	}
 	

--- a/webapp/src/app/shared/widgets/event-widget/event-registry/start-npc-trade-menu.ts
+++ b/webapp/src/app/shared/widgets/event-widget/event-registry/start-npc-trade-menu.ts
@@ -1,0 +1,66 @@
+import { EntityAttributes } from '../../../phaser/entities/cc-entity';
+import {AbstractEvent, EventType} from './abstract-event';
+
+export interface StartNpcTradeMenuData extends EventType {
+	withBranches?: boolean;
+	
+	//Branches
+	traded?: AbstractEvent<any>[];
+	canceled?: AbstractEvent<any>[];
+}
+
+
+export class StartNpcTradeMenu extends AbstractEvent<StartNpcTradeMenuData> {
+	private attributes: EntityAttributes = {
+		withBranches: {
+			type: 'Boolean',
+			optional: true,
+			description: 'Whether or not this trade has event branches',
+			C1: true,
+			C2: true
+		}
+	};
+	
+	getAttributes(): EntityAttributes {
+		return this.attributes;
+	}
+	
+	update() {
+		this.children.length = 0;
+		this.info = this.combineStrings(
+			this.getTypeString('#7ea3ff'),
+			this.getPropString('withBranches'),
+		);
+		
+		if (this.data.withBranches) {
+			this.children[0] = {
+				title: this.getColoredString('Trade. Traded', '#838383'),
+				events: this.data.traded ?? [],
+				draggable: false
+			};
+			this.children[1] = {
+				title: this.getColoredString('Trade. Canceled', '#838383'),
+				events: this.data.canceled ?? [],
+				draggable: false
+			};
+		}
+	}
+	
+	export(): StartNpcTradeMenuData {
+		const out: StartNpcTradeMenuData = {
+			type: this.data.type,
+			withBranches: this.data.withBranches,
+		};
+		if (this.data.withBranches) {
+			out.traded = (this.data.traded ?? []).map(v => v.export());
+			out.canceled = (this.data.canceled ?? []).map(v => v.export());
+		}
+		return out;
+	}
+	
+	protected generateNewDataInternal() {
+		return {
+			withBranches: false
+		};
+	}
+}


### PR DESCRIPTION
Adds event branches to the `START_NPC_TRADE_MENU` event:
![event-branches](https://user-images.githubusercontent.com/56268917/141534720-22e5dfbd-1751-49d1-99f0-09b76804d1e7.png)

Toggling the `withBranches` property adds or removes branches:
![withBranches](https://user-images.githubusercontent.com/56268917/141535427-69972c60-91c2-423d-830c-2d975a392176.png)

This PR also fixes `SHOW_CHOICE` branches not updating when the number of choices is changed.