### PR TITLE
add manual input to graphical select widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+### Changed
+- Added manual input field to graphical selection widget for `Prop`, `Enemy`, `NPC`
+
 ## [1.0.0] 2023-08-04
 
 ### Added

--- a/webapp/src/app/components/widgets/character-widget/character-widget.component.ts
+++ b/webapp/src/app/components/widgets/character-widget/character-widget.component.ts
@@ -66,6 +66,10 @@ export class CharacterWidgetComponent extends OverlayWidget {
 			ogProp = '';
 		}
 		
+		this.comp.manualKey = this.key;
+		this.comp.manualValue = ogProp;
+		this.comp.manualValueChange.subscribe(v => this.setPropType(v, true));
+		
 		this.setPropType(ogProp);
 		await this.updateProps();
 		this.updateRightSide();
@@ -84,6 +88,7 @@ export class CharacterWidgetComponent extends OverlayWidget {
 		if (updateRightSide) {
 			this.updateRightSide();
 		}
+		this.comp.manualValue = prop;
 	}
 	
 	private updateRightSide() {

--- a/webapp/src/app/components/widgets/enemy-single-type-widget/enemy-single-type-widget.component.ts
+++ b/webapp/src/app/components/widgets/enemy-single-type-widget/enemy-single-type-widget.component.ts
@@ -61,6 +61,10 @@ export class EnemySingleTypeWidgetComponent extends OverlayWidget {
 		};
 		this.rightGroup.click = prop => this.setPropType(prop);
 		
+		this.comp.manualKey = this.key;
+		this.comp.manualValue = this.settings[this.key];
+		this.comp.manualValueChange.subscribe(v => this.setPropType(v, true));
+		
 		this.setPropType(this.settings[this.key] ?? '');
 		await this.updateProps();
 		this.updateRightSide();
@@ -79,6 +83,7 @@ export class EnemySingleTypeWidgetComponent extends OverlayWidget {
 		if (updateRightSide) {
 			this.updateRightSide();
 		}
+		this.comp.manualValue = prop;
 	}
 	
 	private updateRightSide() {

--- a/webapp/src/app/components/widgets/prop-type-widget/prop-type-widget.component.ts
+++ b/webapp/src/app/components/widgets/prop-type-widget/prop-type-widget.component.ts
@@ -68,6 +68,11 @@ export class PropTypeWidgetComponent extends OverlayWidget<PropAttributes> {
 		this.rightGroup.click = prop => this.setPropAnim(prop);
 		
 		this.comp.sheets = await lastValueFrom(this.http.getProps());
+		
+		this.comp.manualKey = this.key;
+		this.comp.manualValue = this.settings.propType?.name;
+		this.comp.manualValueChange.subscribe(v => this.setPropType(v));
+		
 		await this.updateProps();
 		this.updatePropAnims();
 		
@@ -91,6 +96,7 @@ export class PropTypeWidgetComponent extends OverlayWidget<PropAttributes> {
 		}
 		this.setSetting(this.nameKey, prop);
 		this.updatePropAnims();
+		this.comp.manualValue = this.settings.propType?.name;
 	}
 	
 	private setPropAnim(propAnim: string) {

--- a/webapp/src/app/components/widgets/shared/image-select-overlay/image-select-list/image-select-list.component.html
+++ b/webapp/src/app/components/widgets/shared/image-select-overlay/image-select-list/image-select-list.component.html
@@ -17,6 +17,9 @@
 		</button>
 	</mat-form-field>
 	<h2 class="pl-4 headline" *ngIf="title">{{title}}</h2>
+	<div class="pl-4 pr-4">
+		<ng-content></ng-content>
+	</div>
 	<div class="list">
 		<ng-container
 			*ngIf="items|listFilter:filter:filterItems as filteredItems"

--- a/webapp/src/app/components/widgets/shared/image-select-overlay/image-select-overlay.component.html
+++ b/webapp/src/app/components/widgets/shared/image-select-overlay/image-select-overlay.component.html
@@ -27,15 +27,6 @@
 			>
 				<ng-container ngProjectAs="left">
 					<div class="flex flex-col h-full mr-1.5 dark-scrollbar-auto">
-						<mat-checkbox
-							*ngIf="showGlobalCheckbox"
-							class="pl-2 pt-2"
-							color="primary"
-							[(ngModel)]="global"
-							(ngModelChange)="globalChange.emit($event)"
-						>
-							use GLOBAL
-						</mat-checkbox>
 						<app-image-select-list
 							[title]="leftGroup.title"
 							[items]="leftGroup.props"
@@ -43,7 +34,29 @@
 							[(filter)]="filter"
 							[selected]="leftGroup.selected"
 							(selectedChange)="leftGroup.click?.(leftGroup.selected === $event ? '' : $event)"
-						></app-image-select-list>
+						>
+							<div *ngIf="manualKey">
+								<mat-form-field
+									appearance="outline"
+									class="no-padding-form-field autoscale-form-field pb-4"
+								>
+									<mat-label>{{manualKey}}</mat-label>
+									<input
+										matInput
+										[ngModel]="manualValue"
+										(ngModelChange)="manualValueChange.emit($event)"
+									>
+								</mat-form-field>
+							</div>
+							<mat-checkbox
+								*ngIf="showGlobalCheckbox"
+								color="primary"
+								[(ngModel)]="global"
+								(ngModelChange)="globalChange.emit($event)"
+							>
+								use GLOBAL
+							</mat-checkbox>
+						</app-image-select-list>
 						<div class="flex-auto grid justify-center items-center">
 							<mat-spinner *ngIf="loading"></mat-spinner>
 						</div>

--- a/webapp/src/app/components/widgets/shared/image-select-overlay/image-select-overlay.component.ts
+++ b/webapp/src/app/components/widgets/shared/image-select-overlay/image-select-overlay.component.ts
@@ -19,7 +19,12 @@ export class ImageSelectOverlayComponent implements OnChanges, OnDestroy {
 	@Input() splitBase = 13;
 	@Input() title = '';
 	@Input() showGlobalCheckbox = false;
-	@Input() loading = true;
+	@Input() loading = false;
+	
+	// input for manual value enter
+	@Input() manualKey?: string;
+	@Input() manualValue?: string;
+	@Output() manualValueChange = new EventEmitter<string>();
 	
 	@Input() sheets: string[] = [];
 	@Input() sheet?: string;


### PR DESCRIPTION
fixes #278

Added input so types from mods or missing ones can still be used.

![image](https://github.com/CCDirectLink/crosscode-map-editor/assets/9483499/eaf6c9c3-ba55-4d83-9c15-053cdcdd203f)

Not added for `ScalableProp` and `ItemDestruct` because they have additional logic for setting a value