### PR TITLE
Added support for selecting the special layer levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Layer level selector now also supports selecting all the named layer levels: `first`, `last`, `light`, `postlight`, `object1`, `object2`, and `object3`.
+
+### Changed
+- Named layer levels will now appear in the layer selector as opposed to a layer appearing on level 0 or 10.
+
+### Fixed
+- Layers on the `first` level should now properly render as though they are below level 0.
+
 ## [1.0.0] 2023-08-04
 
 ### Added

--- a/webapp/src/app/components/layers/layers.component.html
+++ b/webapp/src/app/components/layers/layers.component.html
@@ -59,8 +59,9 @@
 					<span class="label">Level: </span>
 					<mat-form-field>
 						<mat-select fxFlex [disabled]="!selectedLayer" floatPlaceholder="never"
-						            [ngModel]="selectedLayer?.details?.level" (selectionChange)="updateLevel($event.value)">
+						            [ngModel]="selectedLayer?.details?.levelName ?? selectedLayer?.details?.level" (selectionChange)="updateLevel($event.value)">
 							<mat-option *ngFor="let level of map?.levels; let i=index" [value]="i">{{i}}</mat-option>
+							<mat-option *ngFor="let level of map?.specialLevels;" [value]="level">{{level}}</mat-option>
 						</mat-select>
 					</mat-form-field>
 				</div>

--- a/webapp/src/app/components/layers/layers.component.ts
+++ b/webapp/src/app/components/layers/layers.component.ts
@@ -46,7 +46,7 @@ export class LayersComponent implements OnInit {
 	}
 	
 	getDisplayName(layer: CCMapLayer): string {
-		return `${layer.details.name} (${layer.details.level})`;
+		return `${layer.details.name} (${layer.details.levelName ?? layer.details.level})`;
 	}
 	
 	toggleVisibility(event: Event, layer: CCMapLayer) {

--- a/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
+++ b/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
@@ -137,17 +137,23 @@ export class CCMapLayer {
 		
 		oldLayer.destroy();
 		
-		this.updateLevel(this.details.level);
+		this.updateLevel(this.details.levelName ?? this.details.level);
 		this.updateLighter(!!this.details.lighter);
 	}
 	
-	updateLevel(level: number) {
-		this.details.level = level;
+	updateLevel(level: number | string) {
+		if(typeof level == 'string') {
+			this.details.levelName = level;
+			this.details.level = level === 'first' ? 0 : 10;
+		} else {
+			this.details.level = level;
+			delete this.details.levelName;
+		}
 		let zIndex = this.details.level * 10;
 		if (isNaN(zIndex)) {
 			zIndex = 999;
 		}
-		this.layer.depth = this.details.level * 10;
+		this.layer.depth = zIndex;
 	}
 	
 	updateLighter(lighter: boolean) {

--- a/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
+++ b/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
@@ -29,7 +29,7 @@ export class CCMapLayer {
 			} else {
 				details.levelName = details.level;
 				if (details.level.startsWith('first')) {
-					details.level = 0;
+					details.level = -1;
 				} else {
 					// TODO: get actual max level;
 					details.level = 10;
@@ -144,7 +144,7 @@ export class CCMapLayer {
 	updateLevel(level: number | string) {
 		if(typeof level == 'string') {
 			this.details.levelName = level;
-			this.details.level = level === 'first' ? 0 : 10;
+			this.details.level = level === 'first' ? -1 : 10;
 		} else {
 			this.details.level = level;
 			delete this.details.levelName;

--- a/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
+++ b/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
@@ -15,27 +15,6 @@ export class CCMapLayer {
 	}
 	
 	public async init(details: MapLayer) {
-		if (typeof details.level === 'string') {
-			// possible levels
-			// 'first'
-			// 'last'
-			// 'light'
-			// 'postlight'
-			// 'object1'
-			// 'object2'
-			// 'object3'
-			if (!isNaN(<any>details.level)) {
-				details.level = parseInt(details.level, 10);
-			} else {
-				details.levelName = details.level;
-				if (details.level.startsWith('first')) {
-					details.level = -1;
-				} else {
-					// TODO: get actual max level;
-					details.level = 10;
-				}
-			}
-		}
 		// noinspection SuspiciousTypeOfGuard
 		if (typeof details.distance === 'string') {
 			details.distance = parseFloat(details.distance);

--- a/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
+++ b/webapp/src/app/services/phaser/tilemap/cc-map-layer.ts
@@ -142,18 +142,20 @@ export class CCMapLayer {
 	}
 	
 	updateLevel(level: number | string) {
-		if(typeof level == 'string') {
+		//converts stringed numbers like "2" to be numeric.
+		//leaves everything else unchanged.
+		if(!isNaN(+level)) {
+			level = +level;
+		}
+
+		if(typeof level === 'string') {
 			this.details.levelName = level;
 			this.details.level = level === 'first' ? -1 : 10;
 		} else {
 			this.details.level = level;
 			delete this.details.levelName;
 		}
-		let zIndex = this.details.level * 10;
-		if (isNaN(zIndex)) {
-			zIndex = 999;
-		}
-		this.layer.depth = zIndex;
+		this.layer.depth = this.details.level * 10;
 	}
 	
 	updateLighter(lighter: boolean) {

--- a/webapp/src/app/services/phaser/tilemap/cc-map.ts
+++ b/webapp/src/app/services/phaser/tilemap/cc-map.ts
@@ -7,6 +7,15 @@ import { CCMapLayer } from './cc-map-layer';
 export class CCMap {
 	name = '';
 	levels: { height: number }[] = [];
+	specialLevels = [
+		'first',
+		'last',
+		'light',
+		'postlight',
+		'object1',
+		'object2',
+		'object3',
+	];
 	mapWidth = 0;
 	mapHeight = 0;
 	masterLevel = 0;


### PR DESCRIPTION
Adds in support for selecting all the special level types in a layer - specifically `first`, `last`, `light`, `postlight`, `object1`, `object2`, and `object3`. The map editor already has support for loading (and saving) layers with named levels, this merely adds the ability for one to select them (as well as properly displaying them in the layer selector). 

For example, by loading up the map `autumn/path-3-1` in the current version of the map editor, followed by the same map loaded with the new support:
![image](https://github.com/CCDirectLink/crosscode-map-editor/assets/49847844/86d8dbfc-f8f8-4b5e-bf66-fd94df9038e7) ![image](https://github.com/CCDirectLink/crosscode-map-editor/assets/49847844/c468b4bc-813f-449d-8547-90c0d20637de)

As for the selector for the layer levels:
![image](https://github.com/CCDirectLink/crosscode-map-editor/assets/49847844/53dbeabc-b4cd-4e94-88fc-73279c513b04)

These changes also follow the current behavior of the map editor - it treats `first` as though it is level 0, and every other level as though it was level 10.

Closes #286 and #157.