### PR TITLE
Ignore mod when JSON errors accur in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+## Fixed
+- The editor won't freeze if a mod's package.json is invalid.
+
 ## [1.1.0] 2023-08-25
 ### Added
 - Layer level selector now also supports selecting all the named layer levels: `first`, `last`, `light`, `postlight`, `object1`, `object2`, and `object3`.

--- a/common/src/controllers/api.ts
+++ b/common/src/controllers/api.ts
@@ -139,9 +139,13 @@ async function readMods(dir: string) {
 	const packages = new Map<string, { folderName: string, ccmodDependencies?: Map<string, string> }>();
 	
 	for (const [name, pkg] of rawPackages) {
-		const parsed = JSON.parse(pkg as unknown as string);
-		parsed.folderName = name;
-		packages.set(parsed.name, parsed);
+		try {
+			const parsed = JSON.parse(pkg as unknown as string);
+			parsed.folderName = name;
+			packages.set(parsed.name, parsed);
+		} catch (err) {
+			console.error('Invalid json data in package.json of mod: ' + name, err);
+		}
 	}
 	
 	packagesCache = packages;


### PR DESCRIPTION
The editor freezes on a while screen when there are JSON syntax errors in one of the mods `package.json`.
Such a mod can still work without problems in CC if it has a `ccmod.json`
