### PR TITLE
fixed map not loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+### Fixed
+- Fix map "heat/special/cursed-temple" not loading
+
+
 ## [1.1.4] 2023-09-17
 ### Fixed 
 - Fix WallHorizontal/WallVertical having the wrong default size

--- a/webapp/src/app/services/phaser/entities/registry/scalable-prop.ts
+++ b/webapp/src/app/services/phaser/entities/registry/scalable-prop.ts
@@ -118,7 +118,7 @@ export class ScalableProp extends DefaultEntity {
 		scaleSettings.scalableStep = prop.scalableStep!;
 		scaleSettings.baseSize = prop.baseSize!;
 		
-		const size = this.details.settings['size'] as Point;
+		const size = (this.details.settings['size'] as Point | undefined) ?? {x: 1, y: 1};
 		
 		if (!scaleSettings.scalableX || size.x < scaleSettings.baseSize.x) {
 			size.x = scaleSettings.baseSize.x;

--- a/webapp/src/app/services/phaser/tilemap/layer-helper.ts
+++ b/webapp/src/app/services/phaser/tilemap/layer-helper.ts
@@ -3,14 +3,14 @@
 import IsInLayerBounds = Phaser.Tilemaps.Components.IsInLayerBounds;
 import Tile = Phaser.Tilemaps.Tile;
 
-export function customPutTilesAt(tiles: number[][] | Tile[][], layer: Phaser.Tilemaps.TilemapLayer) {
+export function customPutTilesAt(tiles: (number | null | undefined)[][] | Tile[][], layer: Phaser.Tilemaps.TilemapLayer) {
 	
 	const height = tiles.length;
 	const width = tiles[0].length;
 	
 	for (let ty = 0; ty < height; ty++) {
 		for (let tx = 0; tx < width; tx++) {
-			const tile = tiles[ty][tx];
+			const tile = tiles[ty][tx] ?? 0;
 			const index = typeof tile === 'number' ? tile : tile.index;
 			customPutTileAt(index, tx, ty, layer.layer);
 		}


### PR DESCRIPTION
fixes #312
- made "customPutTilesAt" work even if array contains null/undefined
- added default size to scalable prop if it doesn't exist to prevent crashes