### PR TITLE
Made the sort for map listing be numeric-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added Array Widget
 
+### Changed
+- Made the listing of maps in the editor be numeric aware.
+
 ## [1.8.1] 2024-08-01
 ### Fixed
 - The currently selected mod is now properly displayed in the settings menu

--- a/webapp/src/app/components/dialogs/load-map/virtualMapNode.model.ts
+++ b/webapp/src/app/components/dialogs/load-map/virtualMapNode.model.ts
@@ -82,6 +82,6 @@ export class VirtualMapNode {
 			return aIsDir ? -1 : 1;
 		}
 
-		return a.name.localeCompare(b.name);
+		return a.name.localeCompare(b.name, undefined, {numeric: true});
 	}
 }


### PR DESCRIPTION
Old behavior:
<img width="291" height="713" alt="image" src="https://github.com/user-attachments/assets/f367181d-e8d0-4c44-b40f-c51411f989f1" />

New behavior:
<img width="287" height="665" alt="image" src="https://github.com/user-attachments/assets/ed75531c-9a80-418e-9dd3-b901f8238ff5" />
